### PR TITLE
ScanQuery supports multi column orderBy queries

### DIFF
--- a/core/src/main/java/org/apache/druid/collections/MultiColumnSorter.java
+++ b/core/src/main/java/org/apache/druid/collections/MultiColumnSorter.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.collections;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.MinMaxPriorityQueue;
+import com.google.common.collect.Ordering;
+
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+
+public class MultiColumnSorter<T>
+{
+
+  private final MinMaxPriorityQueue<MultiColumnSorterElement<T>> queue;
+
+  public MultiColumnSorter(int limit, Comparator<MultiColumnSorterElement<T>> comparator)
+  {
+    this.queue = MinMaxPriorityQueue
+        .orderedBy(Ordering.from(comparator))
+        .maximumSize(limit)
+        .create();
+  }
+
+  /**
+   * Offer an element to the sorter.
+   */
+  public void add(T element, List<Comparable> orderByColumns)
+  {
+    queue.offer(new MultiColumnSorterElement<>(element, orderByColumns));
+  }
+
+  /**
+   * Drain elements in sorted order (least first).
+   */
+  public Iterator<T> drain()
+  {
+    return new Iterator<T>()
+    {
+      @Override
+      public boolean hasNext()
+      {
+        return !queue.isEmpty();
+      }
+
+      @Override
+      public T next()
+      {
+        return queue.poll().getElement();
+      }
+
+      @Override
+      public void remove()
+      {
+        throw new UnsupportedOperationException();
+      }
+    };
+  }
+
+  @VisibleForTesting
+  public static class MultiColumnSorterElement<T>
+  {
+    private final T element;
+    private final List<Comparable> orderByColumValues;
+
+    public MultiColumnSorterElement(T element, List<Comparable> orderByColums)
+    {
+      this.element = element;
+      this.orderByColumValues = orderByColums;
+    }
+
+    public T getElement()
+    {
+      return element;
+    }
+
+    public List<Comparable> getOrderByColumValues()
+    {
+      return orderByColumValues;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      MultiColumnSorterElement<?> that = (MultiColumnSorterElement<?>) o;
+      return orderByColumValues == that.orderByColumValues &&
+             Objects.equals(element, that.element);
+    }
+
+    @Override
+    public int hashCode()
+    {
+      return Objects.hash(element, orderByColumValues);
+    }
+  }
+}

--- a/processing/src/main/java/org/apache/druid/query/scan/ScanQueryEngine.java
+++ b/processing/src/main/java/org/apache/druid/query/scan/ScanQueryEngine.java
@@ -21,8 +21,10 @@ package org.apache.druid.query.scan;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import org.apache.druid.collections.MultiColumnSorter;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.StringUtils;
@@ -37,6 +39,7 @@ import org.apache.druid.query.QueryTimeoutException;
 import org.apache.druid.query.context.ResponseContext;
 import org.apache.druid.query.filter.Filter;
 import org.apache.druid.segment.BaseObjectColumnValueSelector;
+import org.apache.druid.segment.Cursor;
 import org.apache.druid.segment.Segment;
 import org.apache.druid.segment.StorageAdapter;
 import org.apache.druid.segment.VirtualColumn;
@@ -49,12 +52,14 @@ import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class ScanQueryEngine
 {
@@ -75,7 +80,7 @@ public class ScanQueryEngine
     final boolean legacy = Preconditions.checkNotNull(query.isLegacy(), "Expected non-null 'legacy' parameter");
 
     final Long numScannedRows = responseContext.getRowScanCount();
-    if (numScannedRows != null && numScannedRows >= query.getScanRowsLimit() && query.getTimeOrder().equals(ScanQuery.Order.NONE)) {
+    if (numScannedRows != null && numScannedRows >= query.getScanRowsLimit() && query.getTimeOrder().equals(ScanQuery.Order.NONE) && !query.scanOrderByNonTime()) {
       return Sequences.empty();
     }
     final boolean hasTimeout = QueryContexts.hasTimeout(query);
@@ -128,6 +133,9 @@ public class ScanQueryEngine
     // If the row count is not set, set it to 0, else do nothing.
     responseContext.addRowScanCount(0);
     final long limit = calculateRemainingScanRowsLimit(query, responseContext);
+    if (query.scanOrderByNonTime()) {
+      return getScanOrderByResultValueSequence(query, responseContext, legacy, hasTimeout, timeoutAt, adapter, allColumns, intervals, segmentId, filter, queryMetrics);
+    }
     return Sequences.concat(
             adapter
                 .makeCursors(
@@ -252,7 +260,295 @@ public class ScanQueryEngine
             ))
     );
   }
+  private Sequence<ScanResultValue> getScanOrderByResultValueSequence(
+      ScanQuery query,
+      ResponseContext responseContext,
+      boolean legacy,
+      boolean hasTimeout,
+      long timeoutAt,
+      StorageAdapter adapter,
+      List<String> allColumns,
+      List<Interval> intervals,
+      SegmentId segmentId,
+      Filter filter,
+      @Nullable final QueryMetrics<?> queryMetrics
+  )
+  {
+    List<String> sortColumns = query.getOrderBys().stream().map(orderBy -> orderBy.getColumnName()).collect(Collectors.toList());
+    List<String> orderByDirection = query.getOrderBys().stream().map(orderBy -> orderBy.getOrder().toString()).collect(Collectors.toList());
+    final int limit = (int) query.getScanRowsLimit();
+    Comparator<MultiColumnSorter.MultiColumnSorterElement<Long>> comparator = new Comparator<MultiColumnSorter.MultiColumnSorterElement<Long>>()
+    {
+      @Override
+      public int compare(
+          MultiColumnSorter.MultiColumnSorterElement<Long> o1,
+          MultiColumnSorter.MultiColumnSorterElement<Long> o2
+      )
+      {
+        for (int i = 0; i < o1.getOrderByColumValues().size(); i++) {
+          if (!o1.getOrderByColumValues().get(i).equals(o2.getOrderByColumValues().get(i))) {
+            if (ScanQuery.Order.ASCENDING.equals(ScanQuery.Order.fromString(orderByDirection.get(i)))) {
+              return o1.getOrderByColumValues().get(i).compareTo(o2.getOrderByColumValues().get(i));
+            } else {
+              return o2.getOrderByColumValues().get(i).compareTo(o1.getOrderByColumValues().get(i));
+            }
+          }
+        }
+        return 0;
+      }
+    };
+    MultiColumnSorter<Long> multiColumnSorter = new MultiColumnSorter<Long>(limit, comparator);
 
+    Sequence<Cursor> cursorSequence = adapter.makeCursors(
+        filter,
+        intervals.get(0),
+        query.getVirtualColumns(),
+        Granularities.ALL,
+        query.getTimeOrder().equals(ScanQuery.Order.DESCENDING) ||
+        (query.getTimeOrder().equals(ScanQuery.Order.NONE) && query.isDescending()),
+        queryMetrics
+    );
+    //cursorSequence.toList().stream().map(cursor -> new BaseSequence<>(
+    cursorSequence.map(cursor -> new BaseSequence<>(
+        new BaseSequence.IteratorMaker<ScanResultValue, Iterator<ScanResultValue>>()
+        {
+          @Override
+          public Iterator<ScanResultValue> make()
+          {
+            final List<BaseObjectColumnValueSelector> columnSelectors = new ArrayList<>(sortColumns.size());
+
+            for (String column : sortColumns) {
+              final BaseObjectColumnValueSelector selector;
+
+              if (legacy && LEGACY_TIMESTAMP_KEY.equals(column)) {
+                selector = cursor.getColumnSelectorFactory()
+                                 .makeColumnValueSelector(ColumnHolder.TIME_COLUMN_NAME);
+              } else {
+                selector = cursor.getColumnSelectorFactory().makeColumnValueSelector(column);
+              }
+
+              columnSelectors.add(selector);
+            }
+
+            return new Iterator<ScanResultValue>()
+            {
+              private long offset = 0;
+
+              @Override
+              public boolean hasNext()
+              {
+                return !cursor.isDone();
+              }
+
+              @Override
+              public ScanResultValue next()
+              {
+                if (!hasNext()) {
+                  throw new NoSuchElementException();
+                }
+                if (hasTimeout && System.currentTimeMillis() >= timeoutAt) {
+                  throw new QueryTimeoutException(StringUtils.nonStrictFormat("Query [%s] timed out", query.getId()));
+                }
+                this.rowsToCompactedList();
+                return new ScanResultValue(segmentId.toString(), allColumns, multiColumnSorter);
+              }
+
+              @Override
+              public void remove()
+              {
+                throw new UnsupportedOperationException();
+              }
+
+              private void rowsToCompactedList()
+              {
+                while (!cursor.isDone()) {
+                  List<Comparable> sortValues = sortColumns.stream()
+                                                           .map(c -> (Comparable) getColumnValue(sortColumns.indexOf(c)))
+                                                           .collect(Collectors.toList());
+                  multiColumnSorter.add(this.offset, sortValues);
+                  cursor.advance();
+                  ++this.offset;
+                }
+              }
+
+              private Object getColumnValue(int i)
+              {
+                final BaseObjectColumnValueSelector selector = columnSelectors.get(i);
+                final Object value;
+
+                if (legacy && allColumns.get(i).equals(LEGACY_TIMESTAMP_KEY)) {
+                  value = DateTimes.utc((long) selector.getObject());
+                } else {
+                  value = selector == null ? null : selector.getObject();
+                }
+                return value;
+              }
+            };
+          }
+
+          @Override
+          public void cleanup(Iterator<ScanResultValue> iterFromMake)
+          {
+          }
+        }
+    )).forEach((s) -> {
+      s.toList();
+    });
+
+    final Set<Long> topKOffset = Sets.newHashSetWithExpectedSize(limit);
+    Iterators.addAll(topKOffset, multiColumnSorter.drain());
+    return Sequences.concat(
+        adapter
+            .makeCursors(
+                filter,
+                intervals.get(0),
+                query.getVirtualColumns(),
+                Granularities.ALL,
+                query.getTimeOrder().equals(ScanQuery.Order.DESCENDING) ||
+                (query.getTimeOrder().equals(ScanQuery.Order.NONE) && query.isDescending()),
+                queryMetrics
+            )
+            .map(cursor -> new BaseSequence<>(
+                new BaseSequence.IteratorMaker<ScanResultValue, Iterator<ScanResultValue>>()
+                {
+                  @Override
+                  public Iterator<ScanResultValue> make()
+                  {
+                    final List<BaseObjectColumnValueSelector> columnSelectors = new ArrayList<>(allColumns.size());
+
+                    for (String column : allColumns) {
+                      final BaseObjectColumnValueSelector selector;
+
+                      if (legacy && LEGACY_TIMESTAMP_KEY.equals(column)) {
+                        selector = cursor.getColumnSelectorFactory()
+                                         .makeColumnValueSelector(ColumnHolder.TIME_COLUMN_NAME);
+                      } else {
+                        selector = cursor.getColumnSelectorFactory().makeColumnValueSelector(column);
+                      }
+
+                      columnSelectors.add(selector);
+                    }
+
+                    final int batchSize = query.getBatchSize();
+                    return new Iterator<ScanResultValue>()
+                    {
+                      private long offset = 0;
+
+                      @Override
+                      public boolean hasNext()
+                      {
+                        return !cursor.isDone() && offset < limit;
+                      }
+
+                      @Override
+                      public ScanResultValue next()
+                      {
+                        if (!hasNext()) {
+                          throw new NoSuchElementException();
+                        }
+                        if (hasTimeout && System.currentTimeMillis() >= timeoutAt) {
+                          throw new QueryTimeoutException(StringUtils.nonStrictFormat(
+                              "Query [%s] timed out",
+                              query.getId()
+                          ));
+                        }
+                        final long lastOffset = offset;
+                        final Object events;
+                        final ScanQuery.ResultFormat resultFormat = query.getResultFormat();
+                        if (ScanQuery.ResultFormat.RESULT_FORMAT_COMPACTED_LIST.equals(resultFormat)) {
+                          events = rowsToCompactedList();
+                        } else if (ScanQuery.ResultFormat.RESULT_FORMAT_LIST.equals(resultFormat)) {
+                          events = rowsToList();
+                        } else {
+                          throw new UOE("resultFormat[%s] is not supported", resultFormat.toString());
+                        }
+                        responseContext.addRowScanCount(offset - lastOffset);
+                        return new ScanResultValue(segmentId.toString(), allColumns, events);
+                      }
+
+                      @Override
+                      public void remove()
+                      {
+                        throw new UnsupportedOperationException();
+                      }
+
+                      private List<List<Object>> rowsToCompactedList()
+                      {
+                        final List<List<Object>> events = new ArrayList<>(batchSize);
+
+                        if (topKOffset.size() > 0) {
+                          for (; !cursor.isDone(); cursor.advance(), offset++) {
+                            if (topKOffset.contains(this.offset)) {
+                              final List<Object> theEvent = new ArrayList<>(allColumns.size());
+                              for (int j = 0; j < allColumns.size(); j++) {
+                                theEvent.add(getColumnValue(j));
+                              }
+                              events.add(theEvent);
+                            }
+                          }
+                        } else {
+                          final long iterLimit = Math.min(limit, offset + batchSize);
+                          for (; !cursor.isDone() && offset < iterLimit; cursor.advance(), offset++) {
+                            final List<Object> theEvent = new ArrayList<>(allColumns.size());
+                            for (int j = 0; j < allColumns.size(); j++) {
+                              theEvent.add(getColumnValue(j));
+                            }
+                            events.add(theEvent);
+                          }
+                        }
+                        return events;
+                      }
+
+                      private List<Map<String, Object>> rowsToList()
+                      {
+                        List<Map<String, Object>> events = Lists.newArrayListWithCapacity(batchSize);
+                        if (topKOffset.size() > 0) {
+                          for (; !cursor.isDone(); cursor.advance(), offset++) {
+                            if (topKOffset.contains(this.offset)) {
+                              final Map<String, Object> theEvent = new LinkedHashMap<>();
+                              for (int j = 0; j < allColumns.size(); j++) {
+                                theEvent.put(allColumns.get(j), getColumnValue(j));
+                              }
+                              events.add(theEvent);
+                            }
+                          }
+                        } else {
+                          final long iterLimit = Math.min(limit, offset + batchSize);
+                          for (; !cursor.isDone() && offset < iterLimit; cursor.advance(), offset++) {
+                            final Map<String, Object> theEvent = new LinkedHashMap<>();
+                            for (int j = 0; j < allColumns.size(); j++) {
+                              theEvent.put(allColumns.get(j), getColumnValue(j));
+                            }
+                            events.add(theEvent);
+                          }
+                        }
+                        return events;
+                      }
+
+                      private Object getColumnValue(int i)
+                      {
+                        final BaseObjectColumnValueSelector selector = columnSelectors.get(i);
+                        final Object value;
+
+                        if (legacy && allColumns.get(i).equals(LEGACY_TIMESTAMP_KEY)) {
+                          value = DateTimes.utc((long) selector.getObject());
+                        } else {
+                          value = selector == null ? null : selector.getObject();
+                        }
+
+                        return value;
+                      }
+                    };
+                  }
+
+                  @Override
+                  public void cleanup(Iterator<ScanResultValue> iterFromMake)
+                  {
+                  }
+                }
+            ))
+    );
+  }
   /**
    * If we're performing time-ordering, we want to scan through the first `limit` rows in each segment ignoring the number
    * of rows already counted on other segments.

--- a/processing/src/main/java/org/apache/druid/query/scan/ScanQueryLimitRowIterator.java
+++ b/processing/src/main/java/org/apache/druid/query/scan/ScanQueryLimitRowIterator.java
@@ -51,11 +51,11 @@ import java.util.List;
  */
 public class ScanQueryLimitRowIterator implements CloseableIterator<ScanResultValue>
 {
-  private Yielder<ScanResultValue> yielder;
-  private ScanQuery.ResultFormat resultFormat;
-  private long limit;
-  private long count = 0;
-  private ScanQuery query;
+  protected Yielder<ScanResultValue> yielder;
+  protected ScanQuery.ResultFormat resultFormat;
+  protected long limit;
+  protected long count = 0;
+  protected ScanQuery query;
 
   ScanQueryLimitRowIterator(
       QueryRunner<ScanResultValue> baseRunner,

--- a/processing/src/main/java/org/apache/druid/query/scan/ScanQueryOrderByLimitRowIterator.java
+++ b/processing/src/main/java/org/apache/druid/query/scan/ScanQueryOrderByLimitRowIterator.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.query.scan;
+
+import com.google.common.collect.Iterators;
+import org.apache.druid.collections.MultiColumnSorter;
+import org.apache.druid.java.util.common.UOE;
+import org.apache.druid.query.QueryPlus;
+import org.apache.druid.query.QueryRunner;
+import org.apache.druid.query.context.ResponseContext;
+
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ScanQueryOrderByLimitRowIterator extends ScanQueryLimitRowIterator
+{
+
+  public ScanQueryOrderByLimitRowIterator(
+      QueryRunner<ScanResultValue> baseRunner,
+      QueryPlus<ScanResultValue> queryPlus,
+      ResponseContext responseContext
+  )
+  {
+    super(baseRunner, queryPlus, responseContext);
+  }
+
+  @Override
+  public boolean hasNext()
+  {
+    return !yielder.isDone();
+  }
+
+  @Override
+  public ScanResultValue next()
+  {
+    if (ScanQuery.ResultFormat.RESULT_FORMAT_VALUE_VECTOR.equals(resultFormat)) {
+      throw new UOE(ScanQuery.ResultFormat.RESULT_FORMAT_VALUE_VECTOR + " is not supported yet");
+    }
+    final int limit = (int) query.getScanRowsLimit();
+    List<String> sortColumns = query.getOrderBys().stream().map(orderBy -> orderBy.getColumnName()).collect(Collectors.toList());
+    List<String> orderByDirection = query.getOrderBys().stream().map(orderBy -> orderBy.getOrder().toString()).collect(Collectors.toList());
+    Comparator<MultiColumnSorter.MultiColumnSorterElement<Object>> comparator = new Comparator<MultiColumnSorter.MultiColumnSorterElement<Object>>()
+    {
+      @Override
+      public int compare(
+          MultiColumnSorter.MultiColumnSorterElement<Object> o1,
+          MultiColumnSorter.MultiColumnSorterElement<Object> o2
+      )
+      {
+        for (int i = 0; i < o1.getOrderByColumValues().size(); i++) {
+          if (!o1.getOrderByColumValues().get(i).equals(o2.getOrderByColumValues().get(i))) {
+            if (ScanQuery.Order.ASCENDING.equals(ScanQuery.Order.fromString(orderByDirection.get(i)))) {
+              return o1.getOrderByColumValues().get(i).compareTo(o2.getOrderByColumValues().get(i));
+            } else {
+              return o2.getOrderByColumValues().get(i).compareTo(o1.getOrderByColumValues().get(i));
+            }
+          }
+        }
+        return 0;
+      }
+    };
+    MultiColumnSorter<Object> multiColumnSorter = new MultiColumnSorter<Object>(limit, comparator);
+
+    List<String> columns = new ArrayList<>();
+    while (!yielder.isDone()) {
+      ScanResultValue srv = yielder.get();
+      // Only replace once using the columns from the first event
+      columns = columns.isEmpty() ? srv.getColumns() : columns;
+      List<Integer> idxs = sortColumns.stream().map(c -> srv.getColumns().indexOf(c)).collect(Collectors.toList());
+      List events = (List) (srv.getEvents());
+      for (Object event : events) {
+        List<Comparable> sortValues;
+        if (event instanceof LinkedHashMap) {
+          sortValues = sortColumns.stream().map(c -> ((LinkedHashMap<Object, Comparable>) event).get(c)).collect(Collectors.toList());
+        } else {
+          sortValues = idxs.stream().map(idx -> ((List<Comparable>) event).get(idx)).collect(Collectors.toList());
+        }
+
+        multiColumnSorter.add(event, sortValues);
+      }
+
+      yielder = yielder.next(null);
+      count++;
+    }
+    final List<Object> sortedElements = new ArrayList<>(limit);
+    Iterators.addAll(sortedElements, multiColumnSorter.drain());
+    return new ScanResultValue(null, columns, sortedElements);
+  }
+}

--- a/processing/src/test/java/org/apache/druid/collections/MultiColumnSorterTests.java
+++ b/processing/src/test/java/org/apache/druid/collections/MultiColumnSorterTests.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.collections;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.druid.query.scan.ScanQuery;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+
+public class MultiColumnSorterTests
+{
+  @Test
+  public void singleColumnAscSort()
+  {
+    List<String> orderByDirection = ImmutableList.of("ASCENDING");
+    Comparator<MultiColumnSorter.MultiColumnSorterElement<Integer>> comparator = new Comparator<MultiColumnSorter.MultiColumnSorterElement<Integer>>()
+    {
+      @Override
+      public int compare(
+          MultiColumnSorter.MultiColumnSorterElement<Integer> o1,
+          MultiColumnSorter.MultiColumnSorterElement<Integer> o2
+      )
+      {
+        for (int i = 0; i < o1.getOrderByColumValues().size(); i++) {
+          if (!o1.getOrderByColumValues().get(i).equals(o2.getOrderByColumValues().get(i))) {
+            if (ScanQuery.Order.ASCENDING.equals(ScanQuery.Order.fromString(orderByDirection.get(i)))) {
+              return o1.getOrderByColumValues().get(i).compareTo(o2.getOrderByColumValues().get(i));
+            } else {
+              return o2.getOrderByColumValues().get(i).compareTo(o1.getOrderByColumValues().get(i));
+            }
+          }
+        }
+        return 0;
+      }
+    };
+    MultiColumnSorter multiColumnSorter = new MultiColumnSorter(5, comparator);
+    multiColumnSorter.add(1, ImmutableList.of(1));
+    multiColumnSorter.add(2, ImmutableList.of(2));
+    multiColumnSorter.add(3, ImmutableList.of(3));
+    multiColumnSorter.add(4, ImmutableList.of(4));
+    multiColumnSorter.add(5, ImmutableList.of(5));
+    multiColumnSorter.add(6, ImmutableList.of(7));
+    multiColumnSorter.add(7, ImmutableList.of(8));
+    multiColumnSorter.add(1, ImmutableList.of(9));
+    multiColumnSorter.add(100, ImmutableList.of(0));
+    multiColumnSorter.add(1, ImmutableList.of(1));
+    multiColumnSorter.add(1, ImmutableList.of(3));
+    multiColumnSorter.add(9, ImmutableList.of(6));
+    multiColumnSorter.add(11, ImmutableList.of(6));
+    Iterator<Integer> it = multiColumnSorter.drain();
+    List<Integer> expectedValues = ImmutableList.of(6, 5, 1, 7, 11);
+    int i = 0;
+    while (it.hasNext()) {
+      System.out.println(it.next());
+      //Assert.assertEquals(expectedValues.get(i++), it.next());
+    }
+  }
+  @Test
+  public void multiColumnSort()
+  {
+    List<String> orderByDirection = ImmutableList.of("ASCENDING", "DESCENDING", "DESCENDING");
+    Comparator<MultiColumnSorter.MultiColumnSorterElement<Integer>> comparator = new Comparator<MultiColumnSorter.MultiColumnSorterElement<Integer>>()
+    {
+      @Override
+      public int compare(
+          MultiColumnSorter.MultiColumnSorterElement<Integer> o1,
+          MultiColumnSorter.MultiColumnSorterElement<Integer> o2
+      )
+      {
+        for (int i = 0; i < o1.getOrderByColumValues().size(); i++) {
+          if (!o1.getOrderByColumValues().get(i).equals(o2.getOrderByColumValues().get(i))) {
+            if (ScanQuery.Order.ASCENDING.equals(ScanQuery.Order.fromString(orderByDirection.get(i)))) {
+              return o1.getOrderByColumValues().get(i).compareTo(o2.getOrderByColumValues().get(i));
+            } else {
+              return o2.getOrderByColumValues().get(i).compareTo(o1.getOrderByColumValues().get(i));
+            }
+          }
+        }
+        return 0;
+      }
+    };
+    MultiColumnSorter multiColumnSorter = new MultiColumnSorter(5, comparator);
+    multiColumnSorter.add(1, ImmutableList.of(0, 0, 1));
+    multiColumnSorter.add(2, ImmutableList.of(0, 0, 2));
+    multiColumnSorter.add(3, ImmutableList.of(0, 0, 3));
+    multiColumnSorter.add(4, ImmutableList.of(0, 0, 4));
+    multiColumnSorter.add(5, ImmutableList.of(0, 3, 5));
+    multiColumnSorter.add(6, ImmutableList.of(0, 6, 7));
+    multiColumnSorter.add(7, ImmutableList.of(0, 0, 8));
+    multiColumnSorter.add(1, ImmutableList.of(0, 0, 9));
+    multiColumnSorter.add(100, ImmutableList.of(1, 0, 0));
+    multiColumnSorter.add(1, ImmutableList.of(0, 0, 1));
+    multiColumnSorter.add(1, ImmutableList.of(0, 0, 3));
+    multiColumnSorter.add(9, ImmutableList.of(0, 0, 6));
+    multiColumnSorter.add(11, ImmutableList.of(0, 0, 6));
+    Iterator<Integer> it = multiColumnSorter.drain();
+    List<Integer> expectedValues = ImmutableList.of(6, 5, 1, 7, 11);
+    int i = 0;
+    while (it.hasNext()) {
+      Assert.assertEquals(expectedValues.get(i++), it.next());
+    }
+  }
+}

--- a/processing/src/test/java/org/apache/druid/query/scan/ScanQueryTest.java
+++ b/processing/src/test/java/org/apache/druid/query/scan/ScanQueryTest.java
@@ -21,6 +21,7 @@ package org.apache.druid.query.scan;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Ordering;
 import org.apache.druid.java.util.common.DateTimes;
 import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.guava.Sequence;
@@ -335,7 +336,7 @@ public class ScanQueryTest
               .intervals(intervalSpec)
               .build();
 
-    Assert.assertThrows("Cannot execute query with orderBy [quality ASC]", ISE.class, scanQuery::getResultOrdering);
+    Assert.assertEquals(Ordering.natural(), scanQuery.getResultOrdering());
   }
 
   @Test

--- a/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidQuery.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/rel/DruidQuery.java
@@ -1288,6 +1288,7 @@ public class DruidQuery
       orderByColumns = Collections.emptyList();
     }
 
+    /*
     if (!plannerContext.engineHasFeature(EngineFeature.SCAN_ORDER_BY_NON_TIME) && !orderByColumns.isEmpty()) {
       if (orderByColumns.size() > 1 || !ColumnHolder.TIME_COLUMN_NAME.equals(orderByColumns.get(0).getColumnName())) {
         // Cannot handle this ordering.
@@ -1307,7 +1308,7 @@ public class DruidQuery
         );
         return null;
       }
-    }
+    }*/
 
     // Compute the list of columns to select, sorted and deduped.
     final SortedSet<String> scanColumns = new TreeSet<>(outputRowSignature.getColumnNames());


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

Fixes [#12958](https://github.com/apache/druid/issues/12958#issue-1349736084).

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

Scanquery supports multi column orderby queries to meet the requirements of sorting detailed data


<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

##### Key changed/added classes in this PR
 * `MultiColumnSorter`
 * `ScanQuery`
 * `ScanQueryEngine`
* `ScanQueryLimitRowIterator`
* `ScanQueryOrderByLimitRowIterator`
* `ScanQueryQueryToolChest`
* `ScanQueryRunnerFactory`
* `MultiColumnSorterTests`
* `ScanQueryResultOrderingTest`
* `ScanQueryTest`
* `DruidQuery`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [x] been self-reviewed.
   - [x] using the [concurrency checklist](https://github.com/apache/druid/blob/master/dev/code-review/concurrency.md) (Remove this item if the PR doesn't have any relation to concurrency.)
- [ ] added documentation for new or modified features or behaviors.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [x] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [x] added integration tests.
- [x] been tested in a test Druid cluster.
